### PR TITLE
Set max_connections_to_host to 5 for conns to liquid planner

### DIFF
--- a/synergy
+++ b/synergy
@@ -57,7 +57,9 @@ has http => (
   isa => 'Net::Async::HTTP',
   lazy => 1,
   default => sub {
-    my $http = Net::Async::HTTP->new();
+    my $http = Net::Async::HTTP->new(
+      max_connections_per_host => 5, # seems good?
+    );
 
     shift->io_loop->add($http);
 


### PR DESCRIPTION
Otherwise each lp request will queue up behind the currently
firing request. This number can be increased to whatever limit
LiquidPlanner may have (or set to 0 to be unlimited).