### PR TITLE
When stopping timer, always say task name

### DIFF
--- a/synergy
+++ b/synergy
@@ -1900,8 +1900,7 @@ sub SAID_commit {
 
   my $time = concise( duration( $lp_timer->{running_time} * 3600 ) );
   $self->reply(
-    sprintf("Okay, I've committed $time of work$also.%s",
-      $meta{DONE} ? "  Task was: $task->{name}" : q{}),
+    "Okay, I've committed $time of work$also. Task was: $task->{name}",
     $arg
   );
 


### PR DESCRIPTION
Before, this was only said if you marked the task done. That seems
silly.