### PR TITLE
Add describe_conversation method to channels

### DIFF
--- a/lib/Synergy/Channel/Console.pm
+++ b/lib/Synergy/Channel/Console.pm
@@ -165,4 +165,8 @@ sub describe_event ($self, $event) {
   return "(a console event)";
 }
 
+sub describe_conversation ($self, $event) {
+  return "[console]";
+}
+
 1;

--- a/lib/Synergy/Channel/Slack.pm
+++ b/lib/Synergy/Channel/Slack.pm
@@ -223,6 +223,24 @@ sub describe_event ($self, $event) {
   }
 }
 
+sub describe_conversation ($self, $event) {
+  my $slack_event = $event->transport_data;
+
+  my $channel_id = $event->transport_data->{channel};
+
+
+  if ($slack_event->{is_shared}) {
+    my $channel_id = $event->transport_data->{channel};
+    return "#$channel_id";
+  }
+  elsif ($slack_event->{is_mpim}) {
+    return 'group';
+  }
+  else {
+    return 'private';
+  }
+}
+
 sub user_status_for ($self, $event, $user) {
   $self->slack->load_users->get;
 

--- a/lib/Synergy/Channel/Test.pm
+++ b/lib/Synergy/Channel/Test.pm
@@ -38,6 +38,10 @@ sub send_message ($self, $address, $text, $alts = {}) {
 
 sub describe_event { "(some test event)" }
 
+sub describe_conversation ($self, $event) {
+  return "test";
+}
+
 has sent_messages => (
   isa => 'ArrayRef',
   default  => sub {  []  },

--- a/lib/Synergy/Channel/Twilio.pm
+++ b/lib/Synergy/Channel/Twilio.pm
@@ -168,4 +168,10 @@ sub describe_event ($self, $event) {
   return "an sms from $who";
 }
 
+sub describe_conversation ($self, $event) {
+  my $who = $event->from_user ? $event->from_user->username
+                              : $event->from_address;
+  return $who;
+}
+
 1;

--- a/lib/Synergy/Role/Channel.pm
+++ b/lib/Synergy/Role/Channel.pm
@@ -9,9 +9,21 @@ with 'Synergy::Role::HubComponent';
 
 requires qw(
   describe_event
+  describe_conversation
 
   send_message
   send_message_to_user
 );
 
 1;
+
+=pod
+
+=over 4
+
+=item describe_conversation
+
+A short (single-word) description for the conversation. For channels that don't
+support multiple channels, just the name of the channel is probably fine.
+
+=back


### PR DESCRIPTION
Magic strings are stupid.