### PR TITLE
HTTPServer: log SSL errors, but don't die

### DIFF
--- a/lib/Synergy/HTTPServer.pm
+++ b/lib/Synergy/HTTPServer.pm
@@ -102,7 +102,10 @@ sub start ($self) {
       %opts,
       SSL_cert_file => $self->tls_cert_file,
       SSL_key_file  => $self->tls_key_file,
-      on_ssl_error    => sub { die "SSL error - $_[-1]\n" },
+      on_ssl_error    => sub {
+        # do we even care about this?
+        $Logger->log("HTTPServer: SSL error - $_[-1]");
+      },
     );
   }
   else {

--- a/t/https.t
+++ b/t/https.t
@@ -38,9 +38,19 @@ $synergy->loop->add($http);
 my $port = $synergy->server_port;
 
 {
-  my ($res) = $http->do_request(uri => "https://localhost:$port/ok")->get;
-  ok($res->is_success, 'http server is responding');
+  # Doing this test first, before the successful HTTPS test.
+  # Net::Async::HTTP caches connections by host:port, ignoring scheme
+  # So successful HTTPS connection is reused for the HTTP test, which then succeeds
+  # I consider this to be a Net::Async::HTTP bug
+  my $f = $http->do_request(uri => "http://localhost:$port/ok");
+  ok($f->failure, 'http request to https server failed');
 }
+
+{
+  my ($res) = $http->do_request(uri => "https://localhost:$port/ok")->get;
+  ok($res->is_success, 'https server is responding');
+}
+
 
 done_testing;
 


### PR DESCRIPTION
Otherwise every clown with a broken SSL negotation (eg plain HTTP requests) crashes Synergy.