### PR TITLE
Self-registration!

### DIFF
--- a/lib/Synergy/Channel/Pushover.pm
+++ b/lib/Synergy/Channel/Pushover.pm
@@ -29,7 +29,7 @@ sub http_post {
 }
 
 sub send_message_to_user ($self, $user, $text, $alts = {}) {
-  unless ($user->identities->{ $self->name }) {
+  unless ($user->has_identity_for($self->name)) {
     $Logger->log([
       "can't send message, no api key for %s",
       $user->username,
@@ -37,7 +37,7 @@ sub send_message_to_user ($self, $user, $text, $alts = {}) {
     return;
   }
 
-  my $where = $user->identities->{ $self->name };
+  my $where = $user->identity_for($self->name);
   my $who = $user->username;
 
   $Logger->log([ "sending pushover <$text> to $who" ]);

--- a/lib/Synergy/Channel/Slack.pm
+++ b/lib/Synergy/Channel/Slack.pm
@@ -413,7 +413,7 @@ sub describe_conversation ($self, $event) {
 sub user_status_for ($self, $event, $user) {
   $self->slack->load_users->get;
 
-  my $ident = $user->identities->{ $self->name };
+  my $ident = $user->identity_for($self->name);
   return unless $ident;
 
   return unless my $slack_user = $self->slack->users->{$ident};

--- a/lib/Synergy/Channel/Test.pm
+++ b/lib/Synergy/Channel/Test.pm
@@ -20,7 +20,7 @@ has prefix => (
 );
 
 sub send_message_to_user ($self, $user, $text, $alts = {}) {
-  my $to_address = $user->identities->{ $self->name };
+  my $to_address = $user->identity_for($self->name);
 
   unless ($to_address) {
     confess(

--- a/lib/Synergy/External/Slack.pm
+++ b/lib/Synergy/External/Slack.pm
@@ -328,7 +328,7 @@ sub username ($self, $id) {
 }
 
 sub dm_channel_for_user ($self, $user, $channel) {
-  my $identity = $user->identities->{$channel->name};
+  my $identity = $user->identity_for($channel->name);
   unless ($identity) {
     $Logger->log([
       "No known identity for %s for channel %s",

--- a/lib/Synergy/Hub.pm
+++ b/lib/Synergy/Hub.pm
@@ -81,8 +81,9 @@ has _state_dbh => (
         username TEXT NOT NULL,
         identity_name TEXT NOT NULL,
         identity_value TEXT NOT NULL,
-        FOREIGN KEY (username) REFERENCES users(username),
-        CONSTRAINT constraint_username_identity UNIQUE (username, identity_name)
+        FOREIGN KEY (username) REFERENCES users(username) ON DELETE CASCADE,
+        CONSTRAINT constraint_username_identity UNIQUE (username, identity_name),
+        UNIQUE (identity_name, identity_value)
       );
     });
 

--- a/lib/Synergy/Hub.pm
+++ b/lib/Synergy/Hub.pm
@@ -65,6 +65,27 @@ has _state_dbh => (
       );
     });
 
+    $dbh->do(q{
+      CREATE TABLE IF NOT EXISTS users (
+        username TEXT PRIMARY KEY,
+        lp_id TEXT,
+        is_master INTEGER DEFAULT 0,
+        is_virtual INTEGER DEFAULT 0,
+        is_deleted INTEGER DEFAULT 0
+      );
+    });
+
+    $dbh->do(q{
+      CREATE TABLE IF NOT EXISTS user_identities (
+        id INTEGER PRIMARY KEY,
+        username TEXT NOT NULL,
+        identity_name TEXT NOT NULL,
+        identity_value TEXT NOT NULL,
+        FOREIGN KEY (username) REFERENCES users(username),
+        CONSTRAINT constraint_username_identity UNIQUE (username, identity_name)
+      );
+    });
+
     return $dbh;
   },
 );
@@ -301,10 +322,6 @@ sub synergize {
   #   state_directory: ...
   my $directory = Synergy::UserDirectory->new({ name => '_user_directory' });
 
-  if ($config->{user_directory}) {
-    $directory->load_users_from_file($config->{user_directory});
-  }
-
   my $hub = $class->new({
     user_directory  => $directory,
     defined_kv(time_zone_names => $config->{time_zone_names}),
@@ -314,6 +331,11 @@ sub synergize {
   });
 
   $directory->register_with_hub($hub);
+  $directory->load_users_from_database;
+
+  if ($config->{user_directory}) {
+    $directory->load_users_from_file($config->{user_directory});
+  }
 
   for my $thing (qw( channel reactor )) {
     my $plural    = "${thing}s";

--- a/lib/Synergy/Reactor/Page.pm
+++ b/lib/Synergy/Reactor/Page.pm
@@ -57,7 +57,7 @@ sub handle_page ($self, $event) {
 
   my $paged = 0;
 
-  if ($user->identities->{ $self->page_channel_name } || $user->has_phone) {
+  if ($user->has_identity_for($self->page_channel_name) || $user->has_phone) {
 
     my $page_channel = $self->hub->channel_named($self->page_channel_name);
 
@@ -69,7 +69,7 @@ sub handle_page ($self, $event) {
     $paged = 1;
   }
 
-  if ($user->identities->{ $self->pushover_channel_name }) {
+  if ($user->has_identity_for($self->pushover_channel_name)) {
     my $page_channel = $self->hub->channel_named($self->pushover_channel_name);
 
     my $from = $event->from_user ? $event->from_user->username

--- a/lib/Synergy/Reactor/Register.pm
+++ b/lib/Synergy/Reactor/Register.pm
@@ -1,0 +1,73 @@
+use v5.24.0;
+package Synergy::Reactor::Register;
+use Moose;
+with 'Synergy::Role::Reactor';
+
+use experimental qw(signatures);
+use namespace::clean;
+
+sub listener_specs {
+  return {
+    name      => 'initial registration',
+    method    => 'handle_register_me',
+    exclusive => 1,
+    predicate => sub ($self, $e) {
+      return $e->was_targeted && $e->text =~ /^register me/i;
+    },
+  };
+}
+
+sub handle_register_me ($self, $event) {
+  $event->mark_handled;
+  my $directory = $self->hub->user_directory;
+
+  if ($event->from_user) {
+    my $name = $event->from_user->username;
+    return $event->error_reply("I already know who you are, $name!");
+  }
+
+  # Do we want to allow numbers in usernames? I think no.
+  my ($username) = $event->text =~ /^register me as\s+(.*)$/i;
+
+  return $event->error_reply("usage: register me as [USERNAME]")
+    unless $username;
+
+  $username =~ s/\s*$//g;
+  $username = lc $username;
+
+  return $event->error_reply("Sorry, usernames must be all letters")
+    if $username =~ /[^A-Za-z]/i;
+
+  die "crazy case: event has no from address??" unless $event->from_address;
+
+  if ($directory->user_named($username)) {
+    my $err = join(q{ },
+      "Well this is awkward. I already know someone named $username.",
+      "If that's you, maybe you want <register identity> instead."
+    );
+
+    return $event->error_reply($err);
+  }
+
+  my $user = Synergy::User->new(
+    directory => $directory,
+    username  => $username,
+    is_master => 0,
+    identities => {
+      $event->from_channel->name => $event->from_address,
+    },
+  );
+
+  my $ok = $directory->register_user($user);
+
+  unless ($ok) {
+    my $master = $directory->master_user_string;
+    return $event->error_reply(
+      "Something went wrong while trying to register you. Try talking to $master."
+    );
+  }
+
+  return $event->reply("Hello, $username. Nice to meet you!");
+}
+
+1;

--- a/lib/Synergy/User.pm
+++ b/lib/Synergy/User.pm
@@ -124,7 +124,15 @@ sub tasks_for_expando ($self, $name) {
 has identities => (
   is => 'ro',
   isa => 'HashRef',
+  traits => [ 'Hash' ],
   default => sub {  {}  },
+  handles => {
+    add_identity        => 'set',
+    identity_for        => 'get',
+    has_identity_for    => 'exists',
+    delete_identity_for => 'delete',
+    identity_pairs      => 'kv',
+  },
 );
 
 has phone       => (is => 'ro', isa => 'Str', predicate => 'has_phone');


### PR DESCRIPTION
This converts the user directory into a set of tables in the sqlite database. It'll auto-upgrade from an existing user-directory file on the fly.

The only thing in the user table that probably shouldn't be is `lp_id`, but removing that was gonna be a pain because we also have virtual users who can't self-register. That's a problem for another day.