### PR TITLE
Slack file upload

### DIFF
--- a/lib/Synergy/Channel/Slack.pm
+++ b/lib/Synergy/Channel/Slack.pm
@@ -371,6 +371,11 @@ sub maybe_delete_reply ($self, $slack_event) {
   $self->delete_reply($orig_ts);
 }
 
+sub send_file_to_user ($self, $user, $filename, $content) {
+  my $where = $self->slack->dm_channel_for_user($user, $self);
+  return $self->slack->send_file($where, $filename, $content);
+}
+
 sub _uri_from_event ($self, $event) {
   my $channel = $event->transport_data->{channel};
 

--- a/lib/Synergy/Channel/Slack.pm
+++ b/lib/Synergy/Channel/Slack.pm
@@ -143,6 +143,8 @@ sub start ($self) {
     return if $self->slack->username($slack_event->{user}) eq 'synergy';
 
     my $event = $self->synergy_event_from_slack_event($slack_event);
+    return unless $event;
+
     $self->hub->handle_event($event);
   };
 }


### PR DESCRIPTION
Method to send a file to a user in a private message. It's .. what it is. I could have made api_call a bit more generic but I dunno, this is small and isolated and makes sure nothing else break.

Also a line to ignore Slack events that couldn't be converted to Synergy events, such as the "file uploaded" response event, which looks like a message but is missing a ton fields, including those needed to figure out who the message came from. So `synergy_event_from_slack_event` returns undef, and this makes sure we handle it.