### PR TITLE
Upgrade: Only check reactors/channels specified by config

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -15,8 +15,8 @@ use Net::Async::HTTP;
 use Synergy::Hub;
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users.yaml",
     channels => {
       'test-channel' => {
@@ -35,7 +35,7 @@ my $synergy = Synergy::Hub->synergize(
       pref => { class => 'Synergy::Reactor::Preferences' },
     }
   }
-);
+});
 
 # Tests begin here.
 testing_loop($synergy->loop);

--- a/t/dates.t
+++ b/t/dates.t
@@ -18,8 +18,8 @@ use Net::Async::HTTP;
 use Synergy::Hub;
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory  => "t/data/users.yaml",
     time_zone_names => {
       "America/New_York"  => "🇺🇸",
@@ -38,7 +38,7 @@ my $synergy = Synergy::Hub->synergize(
       echo => { class => 'Synergy::Reactor::Echo' },
     }
   }
-);
+});
 
 sub from_epoch { DateTime->from_epoch(epoch => $_[0]) }
 

--- a/t/exclusive.t
+++ b/t/exclusive.t
@@ -15,8 +15,8 @@ use Net::Async::HTTP;
 use Synergy::Hub;
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users.yaml",
     channels => {
       'test-channel' => {
@@ -33,7 +33,7 @@ my $synergy = Synergy::Hub->synergize(
       echo => { class => 'Synergy::Reactor::Echo' },
     }
   }
-);
+});
 
 # Tests begin here.
 testing_loop($synergy->loop);

--- a/t/httpendpoint.t
+++ b/t/httpendpoint.t
@@ -41,8 +41,8 @@ package Synergy::Channel::Test::HTTPEndpointAuth {
 }
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users.yaml",
     channels => {
       'test-channel-endpoint' => {
@@ -55,7 +55,7 @@ my $synergy = Synergy::Hub->synergize(
       },
     },
   }
-);
+});
 
 # Tests begin here.
 testing_loop($synergy->loop);

--- a/t/https.t
+++ b/t/https.t
@@ -17,8 +17,8 @@ use Plack::Response;
 use Synergy::Hub;
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users.yaml",
     channels => {
       'test-channel' => {
@@ -28,7 +28,7 @@ my $synergy = Synergy::Hub->synergize(
     tls_cert_file => "t/data/synergy.crt",
     tls_key_file => "t/data/synergy.key",
   }
-);
+});
 
 $synergy->server->register_path('/ok', sub {
   return Plack::Response->new(200)->finalize;

--- a/t/httpserver.t
+++ b/t/httpserver.t
@@ -17,8 +17,8 @@ use Plack::Response;
 use Synergy::Hub;
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users.yaml",
     channels => {
       'test-channel' => {
@@ -26,7 +26,7 @@ my $synergy = Synergy::Hub->synergize(
       }
     },
   }
-);
+});
 
 $synergy->server->register_path('/ok', sub {
   return Plack::Response->new(200)->finalize;

--- a/t/lp-task-spec.t
+++ b/t/lp-task-spec.t
@@ -13,8 +13,8 @@ use Synergy::Logger::Test '$Logger';
 use Synergy::Hub;
 
 my $tmpfile = Path::Tiny->tempfile;
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users-lp.yaml",
     channels => {
       'test-channel' => {
@@ -38,7 +38,7 @@ my $synergy = Synergy::Hub->synergize(
     },
     state_dbfile => "$tmpfile",
   }
-);
+});
 
 for my $to_set (
   [ jetta => { lp => { 'default-project-shortcut' => 'pies' } } ],

--- a/t/page.t
+++ b/t/page.t
@@ -20,8 +20,8 @@ my $PAGE = "Hello\n\nfriend.";
 my $tmpfile = Path::Tiny->tempfile;
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users-page.yaml",
     channels => {
       'test-1' => {
@@ -49,7 +49,7 @@ my $synergy = Synergy::Hub->synergize(
     },
     state_dbfile => "$tmpfile",
   }
-);
+});
 
 # Tests begin here.
 testing_loop($synergy->loop);

--- a/t/prometheus.t
+++ b/t/prometheus.t
@@ -16,8 +16,8 @@ use Net::Async::HTTP;
 use Synergy::Hub;
 
 # Initialize Synergy.
-my $synergy = Synergy::Hub->synergize(
-  {
+my $synergy = Synergy::Hub->synergize({
+  config => {
     user_directory => "t/data/users.yaml",
     channels => {
       'test-channel' => {
@@ -33,7 +33,7 @@ my $synergy = Synergy::Hub->synergize(
       prometheus => { class => 'Synergy::Reactor::Prometheus' },
     },
   }
-);
+});
 
 # Tests begin here.
 testing_loop($synergy->loop);


### PR DESCRIPTION
That way if new modules are added (but not used on the running
instance of synergy) an upgrade will still (rightly) succeed.