### PR TITLE
EasyListening: make the idea of a fixed set of listeners optional

### DIFF
--- a/lib/Synergy/Hub.pm
+++ b/lib/Synergy/Hub.pm
@@ -219,10 +219,7 @@ sub handle_event ($self, $event) {
 
   my @hits;
   for my $reactor ($self->reactors) {
-    for my $listener ($reactor->listeners) {
-      next unless $listener->matches_event($event);
-      push @hits, [ $reactor, $listener ];
-    }
+    push @hits, map {; [ $reactor, $_ ] } $reactor->listeners_matching($event);
   }
 
   if (1 < grep {; $_->[1]->is_exclusive } @hits) {

--- a/lib/Synergy/Reactor/Agendoizer.pm
+++ b/lib/Synergy/Reactor/Agendoizer.pm
@@ -6,7 +6,7 @@ use utf8;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Announce.pm
+++ b/lib/Synergy/Reactor/Announce.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::Announce;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use Carp;

--- a/lib/Synergy/Reactor/CatPic.pm
+++ b/lib/Synergy/Reactor/CatPic.pm
@@ -6,7 +6,7 @@ use utf8;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use Synergy::Logger '$Logger';
 

--- a/lib/Synergy/Reactor/Clox.pm
+++ b/lib/Synergy/Reactor/Clox.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Clox;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures lexical_subs);
 use namespace::clean;

--- a/lib/Synergy/Reactor/DC.pm
+++ b/lib/Synergy/Reactor/DC.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::DC;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(lexical_subs signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Echo.pm
+++ b/lib/Synergy/Reactor/Echo.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::Echo;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Eject.pm
+++ b/lib/Synergy/Reactor/Eject.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Eject;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Emit.pm
+++ b/lib/Synergy/Reactor/Emit.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Emit;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/GitLab.pm
+++ b/lib/Synergy/Reactor/GitLab.pm
@@ -4,7 +4,7 @@ use utf8;
 package Synergy::Reactor::GitLab;
 
 use Moose;
-with 'Synergy::Role::Reactor',
+with 'Synergy::Role::Reactor::EasyListening',
      'Synergy::Role::HasPreferences';
 
 use experimental qw(signatures);

--- a/lib/Synergy/Reactor/Help.pm
+++ b/lib/Synergy/Reactor/Help.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Help;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;
@@ -33,9 +33,7 @@ sub handle_help ($self, $event) {
 
   my ($help, $rest) = split /\s+/, $event->text, 2;
 
-  my @help = map {; $_->help_entries }
-             map {; $_->listeners }
-             $self->hub->reactors;
+  my @help = map {; $_->help_entries->@* } $self->hub->reactors;
 
   unless ($rest) {
     my $help_str = join q{, }, uniq sort map {; $_->{title} } @help;

--- a/lib/Synergy/Reactor/HelpSpot.pm
+++ b/lib/Synergy/Reactor/HelpSpot.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::HelpSpot;
 
 use Moose;
-with 'Synergy::Role::Reactor',
+with 'Synergy::Role::Reactor::EasyListening',
      'Synergy::Role::HasPreferences';
 
 use URI;

--- a/lib/Synergy/Reactor/HighFive.pm
+++ b/lib/Synergy/Reactor/HighFive.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::HighFive;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 with 'Synergy::Role::HTTPEndpoint';
 
 use experimental qw(signatures);

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -5,7 +5,7 @@ package Synergy::Reactor::InABox;
 use utf8;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/LiquidPlanner.pm
+++ b/lib/Synergy/Reactor/LiquidPlanner.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::LiquidPlanner;
 
 use Moose;
-with 'Synergy::Role::Reactor',
+with 'Synergy::Role::Reactor::EasyListening',
      'Synergy::Role::HasPreferences',
      'Synergy::Role::ProvidesUserStatus',
      ;

--- a/lib/Synergy/Reactor/NoThreadsPlease.pm
+++ b/lib/Synergy/Reactor/NoThreadsPlease.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::NoThreadsPlease;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Page.pm
+++ b/lib/Synergy/Reactor/Page.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Page;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Preferences.pm
+++ b/lib/Synergy/Reactor/Preferences.pm
@@ -7,7 +7,7 @@ use Try::Tiny;
 use Synergy::Logger '$Logger';
 use utf8;
 
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Prometheus.pm
+++ b/lib/Synergy/Reactor/Prometheus.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::Prometheus;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 with 'Synergy::Role::HTTPEndpoint';
 
 use experimental qw(signatures);

--- a/lib/Synergy/Reactor/RFC.pm
+++ b/lib/Synergy/Reactor/RFC.pm
@@ -4,7 +4,7 @@ use warnings;
 package Synergy::Reactor::RFC;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Register.pm
+++ b/lib/Synergy/Reactor/Register.pm
@@ -1,7 +1,7 @@
 use v5.24.0;
 package Synergy::Reactor::Register;
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/RememberTheMilk.pm
+++ b/lib/Synergy/Reactor/RememberTheMilk.pm
@@ -4,7 +4,7 @@ use utf8;
 package Synergy::Reactor::RememberTheMilk;
 
 use Moose;
-with 'Synergy::Role::Reactor',
+with 'Synergy::Role::Reactor::EasyListening',
      'Synergy::Role::HasPreferences';
 
 use experimental qw(signatures);

--- a/lib/Synergy/Reactor/Reminder.pm
+++ b/lib/Synergy/Reactor/Reminder.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Reminder;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Report.pm
+++ b/lib/Synergy/Reactor/Report.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Report;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Roll.pm
+++ b/lib/Synergy/Reactor/Roll.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::Roll;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Rototron.pm
+++ b/lib/Synergy/Reactor/Rototron.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Rototron;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/SlackID.pm
+++ b/lib/Synergy/Reactor/SlackID.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::SlackID;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Status.pm
+++ b/lib/Synergy/Reactor/Status.pm
@@ -4,7 +4,8 @@ package Synergy::Reactor::Status;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor', 'Synergy::Role::ProvidesUserStatus';
+with 'Synergy::Role::Reactor::EasyListening',
+     'Synergy::Role::ProvidesUserStatus';
 
 use utf8;
 use experimental qw(signatures);

--- a/lib/Synergy/Reactor/Transliterate.pm
+++ b/lib/Synergy/Reactor/Transliterate.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::Transliterate;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Upgrade.pm
+++ b/lib/Synergy/Reactor/Upgrade.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::Upgrade;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(lexical_subs signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Uptime.pm
+++ b/lib/Synergy/Reactor/Uptime.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Uptime;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/VictorOps.pm
+++ b/lib/Synergy/Reactor/VictorOps.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::VictorOps;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Weather.pm
+++ b/lib/Synergy/Reactor/Weather.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Weather;
 use utf8;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Who.pm
+++ b/lib/Synergy/Reactor/Who.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Who;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Yelling.pm
+++ b/lib/Synergy/Reactor/Yelling.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::Yelling;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::EasyListening';
 
 use experimental qw(signatures);
 use namespace::clean;

--- a/lib/Synergy/Role/Reactor.pm
+++ b/lib/Synergy/Role/Reactor.pm
@@ -11,24 +11,11 @@ use Synergy::Listener;
 
 with 'Synergy::Role::HubComponent';
 
-has listeners => (
-  isa => 'ArrayRef',
-  traits  => [ 'Array' ],
-  handles => { listeners => 'elements' },
-  default => sub ($self, @) {
-    my @listeners;
-    for my $spec ($self->listener_specs) {
-      push @listeners, Synergy::Listener->new({
-        reactor => $self,
-        $spec->%{ qw( exclusive name predicate method ) },
-        (exists $spec->{help_entries} ? (help_entries => $spec->{help_entries})
-                                      : ()),
-      });
-    }
-
-    return \@listeners;
-  },
-);
+sub help_entries {
+  # Generally here to be overridden.  Should return an arrayref of help
+  # entries, each with { title => ..., text => ... }
+  return [];
+}
 
 sub start ($self) { }
 

--- a/lib/Synergy/Role/Reactor/EasyListening.pm
+++ b/lib/Synergy/Role/Reactor/EasyListening.pm
@@ -1,0 +1,46 @@
+use v5.24.0;
+use warnings;
+package Synergy::Role::Reactor::EasyListening;
+
+use Moose::Role;
+
+use experimental qw(signatures);
+use namespace::clean;
+
+use Synergy::Listener;
+
+with 'Synergy::Role::Reactor';
+
+has listeners => (
+  isa => 'ArrayRef',
+  traits  => [ 'Array' ],
+  handles => { listeners => 'elements' },
+  default => sub ($self, @) {
+    my @listeners;
+    for my $spec ($self->listener_specs) {
+      push @listeners, Synergy::Listener->new({
+        reactor => $self,
+        $spec->%{ qw( exclusive name predicate method ) },
+        (exists $spec->{help_entries} ? (help_entries => $spec->{help_entries})
+                                      : ()),
+      });
+    }
+
+    return \@listeners;
+  },
+);
+
+around help_entries => sub ($orig, $self, @rest) {
+  my $entries = $self->$orig(@rest);
+  return [
+    @$entries,
+    (map {; $_->help_entries->@* } $self->listeners),
+  ];
+};
+
+sub listeners_matching ($self, $event) {
+  return grep {; $_->matches_event($event) } $self->listeners;
+}
+
+no Moose::Role;
+1;


### PR DESCRIPTION
This paves the way for alternate means of deciding to respond, including
fully parsing an event before responding, to avoid having two message
matchers which can fall out of sync.