### PR TITLE
update timer commit TIME to support single digits

### DIFF
--- a/lib/Synergy/Reactor/LiquidPlanner.pm
+++ b/lib/Synergy/Reactor/LiquidPlanner.pm
@@ -3312,7 +3312,7 @@ sub _handle_timer_commit ($self, $event, $comment) {
   }
 
   my $timer_override;
-  my $time_re = qr{TIME ([0-9]+(?:\.[0-9]+))([hm]?)};
+  my $time_re = qr{TIME ([0-9]+(?:\.[0-9]+)*)([hm]?)};
 
   my %meta;
   $comment //= '';


### PR DESCRIPTION
Though the comment reads that timer commit TIME 1h should be supported, and it seems to me as though the timer override optionally will grab a group for the floating point portion of a command, the regex did not allow for that portion to be optional.  Because of this, timer commit TIME 1h would commit the timer and add the comment "TIME 1h"

This should _hopefully_ fix this, but I haven't tested it!