### PR TITLE
Inabox new prefs datacentre and version

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -145,7 +145,8 @@ sub _handle_create ($self, $event, @args) {
     $self->_get_ssh_key,
   )->then(
     sub (@futures) {
-      Future->done(map { $_->get->{id} } @futures)
+      my @got = grep {; defined } map {; $_->get } @futures;
+      return Future->done(map { $_->{id} } @got);
     }
   )->get;
 

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -628,8 +628,7 @@ sub _update_dns_for_user ($self, $user, $ip) {
 __PACKAGE__->add_preference(
   name      => 'version',
   validator => sub ($self, $value, @) {
-    return (undef, 'version must be jessie or buster') if $value ne 'buster' && $value ne 'jessie';
-
+    return (undef, 'version must be jessie or buster') unless grep { lc $value eq $_ } qw(jessie buster);
     return lc $value;
   },
   default   => 'jessie',

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -555,10 +555,13 @@ sub _box_name_for_user ($self, $user) {
 }
 
 sub _region_for_user ($self, $user) {
+  my $area = $self->get_user_preference($user->username, 'datacentre');
+  return $area if $area;
+
   # this is incredibly stupid, but will do the right thing for the home
-  # location of FM plumbing staff
+  # location of FM plumbing staff without a preference set
   my $tz = $user->time_zone;
-  my ($area) = split '/', $tz;
+  ($area) = split '/', $tz;
   return
     $area eq 'Australia' ? 'sfo2' :
     $area eq 'Europe'    ? 'ams3' :
@@ -631,6 +634,15 @@ __PACKAGE__->add_preference(
   },
   default   => 'jessie',
   description => 'Default Debian version for your fminabox',
+);
+
+__PACKAGE__->add_preference(
+  name      => 'datacentre',
+  validator => sub ($self, $value, @) {
+    return lc $value;
+  },
+  default   => undef,
+  description => 'The Digital Ocean data centre to spin up fminabox in',
 );
 
 1;


### PR DESCRIPTION
This adds new preferences to the inabox reactor.  It also adds the workaround for the reactor crashing when a snapshot isn't found as detailed in #123 

A user can only set a preference based on jessie and buster, but any string can be put in for `/version <foo>` so that if something experimental is being worked on it can be namespaced without needing any configuration change.  Eg `box create /version my-experiment`

The data centre preference will default to the existing behaviour of picking a DC based on timezone, unless a preference has been set.  

At the moment there is no checking of the data centre.  Michael suggested config for this, but i don't think that's the right fit.  For example I recently added Singapore to DC's we upload the nightly snapshot to, but I have no idea what DC's Calvin uploads his WIP buster builds to.  

Ideally i'd like to have access to the snapshot information which lists its available datacentres for that snapshot.  So if their region doesn't match one of the available they get an appropriate message like 
><snapshot-name> is not available in <region> but is available in  <sfo2, sgp1, ... etc>

That will require deeper thinking on how to fix the no snapshot crash bug so the snapshot object isn't thrown away after the id has been extracted.