### PR TITLE
vo: maint timer periodically notifies oncall we're still in maint

### DIFF
--- a/lib/Synergy/Reactor/VictorOps.pm
+++ b/lib/Synergy/Reactor/VictorOps.pm
@@ -255,6 +255,7 @@ EOH
 sub state ($self) {
   return {
     oncall_list => $self->oncall_list,
+    maint_started_by_user => $self->maint_started_by_user,
   };
 }
 
@@ -501,6 +502,7 @@ sub handle_maint_start ($self, $event) {
   })
   ->then(sub ($data) {
     $self->maint_started_by_user($event->from_user->username);
+    $self->save_state;
     $self->_ack_all($event->from_user->username);
   })
   ->then(sub ($nacked) {

--- a/lib/Synergy/Reactor/VictorOps.pm
+++ b/lib/Synergy/Reactor/VictorOps.pm
@@ -418,7 +418,8 @@ sub _check_long_maint ($self) {
 
     my $group_address = $self->oncall_group_address;
     my $maint_duration_m = int($maint_duration_s / 60);
-    my $who = $maint->[0]->{startedBy} eq 'PUBLICAPI' ? $self->maint_started_by_user : $maint->[0]->{startedBy};
+    my $who = $maint->[0]->{startedBy} eq 'PUBLICAPI' ? $self->maint_started_by_user
+      : $self->_vo_to_slack_map->{$maint->[0]->{startedBy}};
 
     $self->oncall_channel->send_message(
       $self->maint_warning_address,


### PR DESCRIPTION
Sometimes operators forget to demaint.

Create a timer that fires every 30 minutes to @oncall in plumbing and remind them we're in maint.

Not sure if how i've set up the timer etc is the best way to do things.  Especially removing the timer.

