### PR TITLE
Fix vo demaint noresolve

### DIFF
--- a/lib/Synergy/Reactor/VictorOps.pm
+++ b/lib/Synergy/Reactor/VictorOps.pm
@@ -706,7 +706,7 @@ sub handle_maint_end ($self, $event) {
       return Future->done($timestamp, $instance_id);
     })
     ->then(sub ($timestamp, $instance_id) {
-      if (grep {; $_ =~ qr{\A/nor(?:esolve)?\z/} } @args) {
+      if (grep {; $_ =~ qr{\A/nor(?:esolve)?\z} } @args) {
         return Future->done($instance_id);
       }
 

--- a/t/victorops.t
+++ b/t/victorops.t
@@ -286,14 +286,30 @@ subtest 'exit maint' => sub {
     gen_response(200, {}),
   );
 
-  send_message('synergy: demaint /resolve', 'alice');
+  send_message('synergy: demaint', 'alice');
   cmp_deeply(
     clear_sent_message_queue(),
     [
       'Successfully resolved 3 incidents. The board is clear!',
       '🚨 VO maint cleared. Good job everyone!'
     ],
-    'demaint /resolve'
+    'demaint'
+  );
+
+  @VO_RESPONSES = (
+    gen_response(200, { activeInstances => [{ isGlobal => 1, instanceId => 42, startedAt => 86400000 }] }),
+    gen_response(200, $incidents),
+    $patch_responder,
+    gen_response(200, {}),
+  );
+
+  send_message('synergy: demaint /noresolve', 'alice');
+  cmp_deeply(
+    clear_sent_message_queue(),
+    [
+      '🚨 VO maint cleared. Good job everyone!'
+    ],
+    'demaint /noresolve'
   );
 };
 


### PR DESCRIPTION
It hasn't been possible to demaint without resolving since the default behaviour was changed.  Was just a minor error in the regex.  Well, it could work if you knew it was demaint /noresolve/ with the trailing slash being required

I've also updated the tests to have a test case for both resolving and not resolving incidents